### PR TITLE
Allow copying files from remote host(s) to local host

### DIFF
--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -517,11 +517,6 @@ future releases - use self.run_command instead", DeprecationWarning)
           created as long as permissions allow.
 
         .. note ::
-          Path separation is handled client side so it is possible to copy
-          to/from hosts with differing path separators, like from/to Linux
-          and Windows.
-
-        .. note ::
           File names will be de-duplicated by appending the hostname to the
           filepath.
 
@@ -538,4 +533,4 @@ future releases - use self.run_command instead", DeprecationWarning)
                                                 password=self.password,
                                                 port=self.port, pkey=self.pkey,
                                                 forward_ssh_agent=self.forward_ssh_agent)
-        return self.host_clients[host].copy_file_to_local(remote_file, local_file + '_' + host)
+        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]))

--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -496,23 +496,24 @@ future releases - use self.run_command instead", DeprecationWarning)
                                 {'recurse' : recurse})
                 for host in self.hosts]
 
-    def _copy_file(self, host, local_file, remote_file, recurse=False):
+    def _copy_file(self, host, local_file, remote_file, recurse):
         """Make sftp client, copy file"""
         if not self.host_clients[host]:
             self.host_clients[host] = SSHClient(host, user=self.user,
                                                 password=self.password,
                                                 port=self.port, pkey=self.pkey,
                                                 forward_ssh_agent=self.forward_ssh_agent)
-        return self.host_clients[host].copy_file(local_file, remote_file)
+        return self.host_clients[host].copy_file(local_file, remote_file, recurse=recurse)
 
-    def copy_file_to_local(self, remote_file, local_file):
+    def copy_file_to_local(self, remote_file, local_file, recurse=False):
         """Copy remote file to local file in parallel
 
         :param remote_file: remote filepath to copy to local host
         :type remote_file: str
         :param local_file: local filepath on local host to copy file to
         :type local_file: str
-
+        :param recurse: whether or not to recurse
+        :type recurse: bool
         .. note ::
           Local directories in `local_file` that do not exist will be
           created as long as permissions allow.
@@ -524,14 +525,14 @@ future releases - use self.run_command instead", DeprecationWarning)
         :rtype: List(:mod:`gevent.Greenlet`) of greenlets for remote copy \
         commands
         """
-        return [self.pool.spawn(self._copy_file_to_local, host, remote_file, local_file)
+        return [self.pool.spawn(self._copy_file_to_local, host, remote_file, local_file, recurse)
                 for host in self.hosts]
 
-    def _copy_file_to_local(self, host, remote_file, local_file):
+    def _copy_file_to_local(self, host, remote_file, local_file, recurse):
         """Make sftp client, copy file to local"""
         if not self.host_clients[host]:
             self.host_clients[host] = SSHClient(host, user=self.user,
                                                 password=self.password,
                                                 port=self.port, pkey=self.pkey,
                                                 forward_ssh_agent=self.forward_ssh_agent)
-        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]))
+        return self.host_clients[host].copy_file_to_local(remote_file, '_'.join([local_file, host]), recurse=recurse)

--- a/pssh/pssh_client.py
+++ b/pssh/pssh_client.py
@@ -503,3 +503,39 @@ future releases - use self.run_command instead", DeprecationWarning)
                                                 port=self.port, pkey=self.pkey,
                                                 forward_ssh_agent=self.forward_ssh_agent)
         return self.host_clients[host].copy_file(local_file, remote_file)
+
+    def copy_file_to_local(self, remote_file, local_file):
+        """Copy remote file to local file in parallel
+
+        :param remote_file: remote filepath to copy to local host
+        :type remote_file: str
+        :param local_file: local filepath on local host to copy file to
+        :type local_file: str
+
+        .. note ::
+          Local directories in `local_file` that do not exist will be
+          created as long as permissions allow.
+
+        .. note ::
+          Path separation is handled client side so it is possible to copy
+          to/from hosts with differing path separators, like from/to Linux
+          and Windows.
+
+        .. note ::
+          File names will be de-duplicated by appending the hostname to the
+          filepath.
+
+        :rtype: List(:mod:`gevent.Greenlet`) of greenlets for remote copy \
+        commands
+        """
+        return [self.pool.spawn(self._copy_file_to_local, host, remote_file, local_file)
+                for host in self.hosts]
+
+    def _copy_file_to_local(self, host, remote_file, local_file):
+        """Make sftp client, copy file to local"""
+        if not self.host_clients[host]:
+            self.host_clients[host] = SSHClient(host, user=self.user,
+                                                password=self.password,
+                                                port=self.port, pkey=self.pkey,
+                                                forward_ssh_agent=self.forward_ssh_agent)
+        return self.host_clients[host].copy_file_to_local(remote_file, local_file + '_' + host)

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -373,15 +373,15 @@ class SSHClient(object):
         if remote_dir_exists and recurse:
             return self._copy_dir_to_local(remote_file, local_file)
         elif remote_dir_exists and not recurse:
-            raise ValueError("Recurse must be true if local_file is a "
+            raise ValueError("Recurse must be true if remote_file is a "
                              "directory.")
         destination = self._parent_path_split(local_file)
         if not os.path.exists(destination):
             try:
                 os.makedirs(destination)
-            except OSError, exception:
+            except OSError:
                 logger.error("Unable to create local directory structure.")
-                raise exception
+                raise
         try:
             sftp.get(remote_file, local_file)
         except Exception, error:

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -335,3 +335,48 @@ class SSHClient(object):
         else:
             logger.info("Copied local file %s to remote destination %s:%s",
                         local_file, self.host, remote_file)
+
+    def _copy_dir_to_local(self, remote_dir, local_dir):
+        """Copies the remote directory to the local host."""
+        sftp = self._make_sftp()
+        file_list = sftp.listdir(remote_dir)
+        for file_name in file_list:
+            remote_path = os.path.join(remote_dir, file_name)
+            local_path = os.path.join(local_dir, file_name)
+            self.copy_file_to_local(remote_path, local_path, recurse=True)
+
+    def copy_file_to_local(self, remote_file, local_file, recurse=False):
+        """Copy remote file to local host via SFTP/SCP
+
+        Copy is done natively using SFTP/SCP version 2 protocol, no scp command \
+        is used or required.
+
+        :param remote_file: Remote filepath to copy the file from.
+        :type remote_file: str
+        :param local_file: Local filepath where the file will be copied.
+        :type local_file: str
+        :param recurse: Whether or not to recursively copy directories.
+        :type recurse: bool
+        """
+        sftp = self._make_sftp()
+        try:
+            sftp.listdir(remote_file)
+            remote_dir_exists = True
+        except IOError or OSError:
+            remote_dir_exists = False
+        if remote_dir_exists and recurse:
+            return self._copy_dir_to_local(remote_file, local_file)
+        destination = [_dir for _dir in local_file.split(os.path.sep)
+                       if _dir][:-1][0]
+        if local_file.startswith(os.path.sep):
+            destination = os.path.sep + destination
+        if not os.path.exists(destination):
+            os.mkdir(destination)
+        try:
+            sftp.get(remote_file, local_file)
+        except Exception, error:
+            logger.error("Error occured copying file %s from remote destination %s:%s - %s",
+                         local_file, self.host, remote_file, error)
+        else:
+            logger.info("Copied local file %s from remote destination %s:%s",
+                        local_file, self.host, remote_file)

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -319,8 +319,6 @@ class SSHClient(object):
                              "directory.")
         sftp = self._make_sftp()
         destination = self._parent_path_split(remote_file)
-        if remote_file.startswith(os.path.sep) or not destination:
-            destination = os.path.sep + destination
         try:
             sftp.stat(destination)
         except IOError:

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -357,6 +357,9 @@ class SSHClient(object):
         :type local_file: str
         :param recurse: Whether or not to recursively copy directories.
         :type recurse: bool
+
+        :raises: :mod:'ValueError' when a directory is supplied to remote_file \
+        and recurse is not set
         """
         sftp = self._make_sftp()
         try:
@@ -366,6 +369,9 @@ class SSHClient(object):
             remote_dir_exists = False
         if remote_dir_exists and recurse:
             return self._copy_dir_to_local(remote_file, local_file)
+        elif remote_dir_exists and not recurse:
+            raise ValueError("Recurse must be true if local_file is a "
+                             "directory.")
         destination = [_dir for _dir in local_file.split(os.path.sep)
                        if _dir][:-1][0]
         if local_file.startswith(os.path.sep):

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -377,7 +377,10 @@ class SSHClient(object):
         if local_file.startswith(os.path.sep):
             destination = os.path.sep + destination
         if not os.path.exists(destination):
-            os.mkdir(destination)
+            try:
+                os.makedirs(destination)
+            except OSError:
+                logger.error("Unable to create local directory structure.")
         try:
             sftp.get(remote_file, local_file)
         except Exception, error:

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -318,11 +318,7 @@ class SSHClient(object):
             raise ValueError("Recurse must be true if local_file is a "
                              "directory.")
         sftp = self._make_sftp()
-        try:
-            destination = [_dir for _dir in remote_file.split(os.path.sep)
-                           if _dir][:-1][0]
-        except IndexError:
-            destination = ''
+        destination = self._parent_path_split(remote_file)
         if remote_file.startswith(os.path.sep) or not destination:
             destination = os.path.sep + destination
         try:
@@ -393,8 +389,11 @@ class SSHClient(object):
 
     @staticmethod
     def _parent_path_split(file_path):
-        destination = [_dir for _dir in file_path.split(os.path.sep)
-                       if _dir][:-1][0]
-        if file_path.startswith(os.path.sep):
+        try:
+            destination = [_dir for _dir in file_path.split(os.path.sep)
+                            if _dir][:-1][0]
+        except IndexError:
+            destination = ''
+        if file_path.startswith(os.path.sep) or not destination:
             destination = os.path.sep + destination
         return destination

--- a/pssh/ssh_client.py
+++ b/pssh/ssh_client.py
@@ -318,10 +318,7 @@ class SSHClient(object):
             raise ValueError("Recurse must be true if local_file is a "
                              "directory.")
         sftp = self._make_sftp()
-        destination = [_dir for _dir in remote_file.split(os.path.sep)
-                       if _dir][:-1][0]
-        if remote_file.startswith(os.path.sep):
-            destination = os.path.sep + destination
+        destination = self._parent_path_split(remote_file)
         try:
             sftp.stat(destination)
         except IOError:
@@ -372,15 +369,13 @@ class SSHClient(object):
         elif remote_dir_exists and not recurse:
             raise ValueError("Recurse must be true if local_file is a "
                              "directory.")
-        destination = [_dir for _dir in local_file.split(os.path.sep)
-                       if _dir][:-1][0]
-        if local_file.startswith(os.path.sep):
-            destination = os.path.sep + destination
+        destination = self._parent_path_split(local_file)
         if not os.path.exists(destination):
             try:
                 os.makedirs(destination)
-            except OSError:
+            except OSError, exception:
                 logger.error("Unable to create local directory structure.")
+                raise exception
         try:
             sftp.get(remote_file, local_file)
         except Exception, error:
@@ -389,3 +384,11 @@ class SSHClient(object):
         else:
             logger.info("Copied local file %s from remote destination %s:%s",
                         local_file, self.host, remote_file)
+
+    @staticmethod
+    def _parent_path_split(file_path):
+        destination = [_dir for _dir in file_path.split(os.path.sep)
+                       if _dir][:-1][0]
+        if file_path.startswith(os.path.sep):
+            destination = os.path.sep + destination
+        return destination

--- a/tests/test_pssh_client.py
+++ b/tests/test_pssh_client.py
@@ -338,6 +338,7 @@ class ParallelSSHClientTest(unittest.TestCase):
                         msg="SFTP copy failed")
         for filepath in [local_filename, remote_filename]:
             os.unlink(filepath)
+        shutil.rmtree(remote_test_dir)
         del client
 
     def test_pssh_client_directory(self):
@@ -392,6 +393,7 @@ class ParallelSSHClientTest(unittest.TestCase):
                         msg="SFTP copy failed")
         for filepath in [remote_filename, local_filename]:
             os.unlink(filepath)
+        shutil.rmtree(local_test_dir)
         del client
         server.join()
 

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -141,7 +141,7 @@ not match source %s" % (copied_file_data, test_file_data))
             os.rmdir(dirpath)
         del client
 
-    def test_ssh_client_directory(self):
+    def test_ssh_client_local_directory(self):
         """Tests copying directories with SSH client. Copy all the files from
         local directory to server, then make sure they are all present."""
         test_file_data = 'test'
@@ -168,6 +168,28 @@ not match source %s" % (copied_file_data, test_file_data))
             self.assertTrue(os.path.isfile(path))
         shutil.rmtree(local_test_path)
         shutil.rmtree(remote_test_path)
+
+    def test_ssh_client_copy_remote_directory(self):
+        """Tests copying a remote directory to the localhost"""
+        remote_test_directory = 'remote_test_dir'
+        local_test_directory = 'local_test_dir'
+        os.mkdir(remote_test_directory)
+        test_files = []
+        for i in range(0, 10):
+            file_name = 'foo' + str(i)
+            test_files.append(file_name)
+            file_path = os.path.join(remote_test_directory, file_name)
+            test_file = open(file_path, 'w')
+            test_file.write('test')
+            test_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        client.copy_file_to_local(remote_test_directory, local_test_directory, recurse=True)
+        for test_file in test_files:
+            file_path = os.path.join(local_test_directory, test_file)
+            self.assertTrue(os.path.exists(file_path))
+        shutil.rmtree(remote_test_directory)
+        shutil.rmtree(local_test_directory)
 
     def test_ssh_client_directory_no_recurse(self):
         """Tests copying directories with SSH client. Copy all the files from

--- a/tests/test_ssh_client.py
+++ b/tests/test_ssh_client.py
@@ -185,6 +185,78 @@ not match source %s" % (copied_file_data, test_file_data))
         self.assertRaises(ValueError, client.copy_file, local_test_path, remote_test_path)
         shutil.rmtree(local_test_path)
 
+    def test_ssh_client_sftp_from_remote(self):
+        """Test copying a file from a remote host to the local host. Copy
+        remote filename to local host, check that the data is intact, make a
+        directory on the localhost, then delete the file and directory."""
+        test_file_data = 'test'
+        remote_filename = 'test_remote'
+        local_test_dir, local_filename = 'local_test_dir', 'test_local'
+        local_filename = os.path.join(local_test_dir, local_filename)
+        remote_file = open(remote_filename, 'w')
+        remote_file.write(test_file_data)
+        remote_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        client.copy_file_to_local(remote_filename, local_filename)
+        self.assertTrue(os.path.isdir(local_test_dir),
+                        msg="SFTP create local directory failed")
+        self.assertTrue(os.path.isfile(local_filename),
+                        msg="SFTP copy failed")
+        copied_file = open(local_filename, 'r')
+        copied_file_data = copied_file.readlines()[0].strip()
+        copied_file.close()
+        self.assertEqual(test_file_data, copied_file_data,
+                         msg="Data in destination file %s does \
+not match source %s" % (copied_file_data, test_file_data))
+        for filepath in [local_filename, remote_filename]:
+            os.remove(filepath)
+        os.rmdir(local_test_dir)
+        del client
+
+    def test_ssh_client_sftp_from_remote_directory(self):
+        """Tests copying remote files to local directory. Copy all the files
+        from the remote directory, then make sure they're all present."""
+        test_file_data = 'test'
+        remote_test_path = 'directory_test_remote'
+        local_test_path = 'directory_test_local'
+        os.mkdir(remote_test_path)
+        local_file_paths = []
+        for i in range(0, 10):
+            remote_file_path = os.path.join(remote_test_path, 'foo' + str(i))
+            local_file_path = os.path.join(local_test_path, 'foo' + str(i))
+            local_file_paths.append(local_file_path)
+            test_file = open(remote_file_path, 'w')
+            test_file.write(test_file_data)
+            test_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        client.copy_file_to_local(remote_test_path, local_test_path, recurse=True)
+        for path in local_file_paths:
+            self.assertTrue(os.path.isfile(path))
+        shutil.rmtree(local_test_path)
+        shutil.rmtree(remote_test_path)
+
+    def test_ssh_client_remote_directory_no_recurse(self):
+        """Tests copying directories with SSH client. Copy all the files from
+        local directory to server, then make sure they are all present."""
+        test_file_data = 'test'
+        remote_test_path = 'directory_test'
+        local_test_path = 'directory_test_copied'
+        os.mkdir(remote_test_path)
+        local_file_paths = []
+        for i in range(0, 10):
+            remote_file_path = os.path.join(remote_test_path, 'foo' + str(i))
+            local_file_path = os.path.join(local_test_path, 'foo' + str(i))
+            local_file_paths.append(local_file_path)
+            test_file = open(remote_file_path, 'w')
+            test_file.write(test_file_data)
+            test_file.close()
+        client = SSHClient(self.host, port=self.listen_port,
+                           pkey=self.user_key)
+        self.assertRaises(ValueError, client.copy_file_to_local, remote_test_path, local_test_path)
+        shutil.rmtree(remote_test_path)
+
     def test_ssh_agent_authentication(self):
         """Test authentication via SSH agent.
         Do not provide public key to use when creating SSHClient,


### PR DESCRIPTION
Adds support for copying files from remote hosts to local host as described in #40.

A new method, `copy_file_to_local`, has been added to both `pssh_client` and `ssh_client`.  In `ssh_client`, its logic is pretty similar to `copy_file`, but was different enough that I figured it would be better to create a new method rather than make `copy_file` more complex. In `pssh_client`, the logic is almost identical between `copy_file` and `copy_file_to_local`; the method was duplicated to maintain the pattern between `ssh_client` and `pssh_client`.

While I think keeping `copy_file` simple and creating a new method is better, I also see the benefit of using one method to perform both functions, and am completely open to rolling the two functions together.

Filenames are de-duplicated by appending an underscore followed by the hostname when using `pssh_client` to copy files to the local host.