### PR TITLE
Solve KeyError from threading on Exit

### DIFF
--- a/pssh/__init__.py
+++ b/pssh/__init__.py
@@ -27,6 +27,7 @@ The `libev event loop library <http://software.schmorp.de/pkg/libev.html>`_ is u
 
 See :mod:`pssh.ParallelSSHClient` and :mod:`pssh.SSHClient` for class documentation.
 """
+import gevent.monkey; gevent.monkey.patch_thread()
 import logging
 from .utils import enable_host_logger
 from .pssh_client import ParallelSSHClient


### PR DESCRIPTION
KeyError is given when threading library (which has been patched) exits.

See http://stackoverflow.com/questions/8774958/keyerror-in-module-threading-after-a-successful-py-test-run
for a detailed explanation of the problem with loading the threading lib
before gevent.monkey.patch_thread() is called.

Replication:
Python 2.7.6 (default, Mar 22 2014, 22:59:56)
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pssh
>>> (CTRL-D)
Exception KeyError: KeyError(140521151242640,) in <module 'threading'
from '/usr/lib/python2.7/threading.pyc'> ignored

In contrast, monkey patching before import logging allows a clean exit
(import logging loads the threading lib).